### PR TITLE
Random file of dir when a dir is passed

### DIFF
--- a/lock.sh
+++ b/lock.sh
@@ -197,8 +197,15 @@ case "$1" in
 			mkdir -p "$folder"
 		fi
 
+		# get random file in dir if passed argument is a dir
+		user_input=$2
+		if [ -d $user_input ]; then
+			user_input=($user_input/*)
+			user_input=${user_input[RANDOM % ${#user_input[@]}]}
+		fi
+		
 		# get user image
-		cp "$2" "$user_image"
+		cp "$user_input" "$user_image"
 		if [ ! -f $user_image ]; then
 			echo "Please specify the path to the image you would like to use"
 			exit 1


### PR DESCRIPTION
If the user passes a directory when updating via` -u <dir>` then this code selects a random file from the directory and uses it instead.

This is useful so one can update the lock image on boot and have a random image every reboot (Adds variety)