### PR TITLE
Add system suspend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Make sure you have following packages installed.
 * [xrandr](https://www.x.org/wiki/Projects/XRandR/) - depends for xdpyinfo
 * [background.jpg](https://unsplash.com/) - find your fav background image
 
+*Note: systemd is required for the suspend feature.*
+
 ### Arch users
 
 To install required packages
@@ -150,6 +152,34 @@ Use dim + blurred image as lockscreen background
 
 ```
 betterlockscreen -l dimblur
+```
+
+---
+
+### To suspend system with lockscreen
+
+Original image as background
+
+```
+betterlockscreen -s
+```
+
+Use dimmed image as lockscreen background
+
+```
+betterlockscreen -s dim
+```
+
+Use blurred image as lockscreen background
+
+```
+betterlockscreen -s blur
+```
+
+Use dim + blurred image as lockscreen background
+
+```
+betterlockscreen -s dimblur
 ```
 
 ---

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -132,6 +132,14 @@ case "$1" in
 		echo "              Ex: betterlockscreen -l dimblur (for dimmed + blurred background)"
 		echo
 		echo
+		echo "          -s --suspend"
+		echo "              to suspend system and lock screen, Ex. betterlockscreen -s"
+		echo "              you can also use dimmed or blurred background for lockscreen"
+		echo "              Ex: betterlockscreen -s dim (for dimmed background)"
+		echo "              Ex: betterlockscreen -s blur (for blurred background)"
+		echo "              Ex: betterlockscreen -s dimblur (for dimmed + blurred background)"
+		echo
+		echo
 		echo "          -w --wall"
 		echo "              you can also set lockscreen background as wallpaper"
 		echo "              to set wallpaper. Ex betterlockscreen -w or betterlockscreen --wall"
@@ -173,6 +181,39 @@ case "$1" in
 				;;
 		esac
 		;;
+
+	-s | --suspend)
+		case "$2" in
+			"")
+				# default lockscreen
+				prelock
+				systemctl suspend && lock "$l_resized"
+				postlock
+				;;
+
+			dim)
+				# lockscreen with dimmed background
+				prelock
+				systemctl suspend && lock "$l_dim"
+				postlock
+				;;
+
+			blur)
+				# set lockscreen with blurred background
+				prelock
+				systemctl suspend && lock "$l_blur"
+				postlock
+				;;
+
+			dimblur)
+				# set lockscreen with dimmed + blurred background
+				prelock
+				systemctl suspend && lock "$l_dimblur"
+				postlock
+				;;
+		esac
+		;;
+
 
 	-w | --wall)
 		case "$2" in


### PR DESCRIPTION
I made these changes locally on the original version of this script but wanted to share them now that a license has been added.

This PR adds a suspend option to the script that allows the system to be resumed with the selected lockscreen. There are several ways to accomplish this outside of the script, but I personally prefer to have the script natively support this on my system.