### PR TITLE
Add custom blurring level, speed up blur

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -154,6 +154,12 @@ case "$1" in
 		echo "              used to set a custom resolution for the image cache."
 		echo "              Ex: betterlockscreen -u path/to/image.png -r 1920x1080"
 		echo "              Ex: betterlockscreen -u path/to/image.png --resolution 3840x1080"
+		echo
+		echo "          -b --blur"
+		echo "              to be used after -u"
+		echo "              used to set blur intensity. Default to 1."
+		echo "              Ex: betterlockscreen -u path/to/image.png -b 3"
+		echo "              Ex: betterlockscreen -u path/to/image.png --blur 0.5"
     echo
 		;;
 
@@ -247,6 +253,30 @@ case "$1" in
 		;;
 
 	-u | --update)
+		background="$2"
+		shift 2
+
+		# find your resolution so images can be resized to match your screen resolution
+		y_res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
+		# default blur level
+		blur_level=1
+
+		# parse update arguments
+		while [ $# -gt 0 ]; do
+		    case "$1" in
+			-r | --resolution )
+			    y_res="$2"
+			    shift 2
+			    ;;
+			-b | --blur )
+			    blur_level="$2"
+			    shift 2
+			    ;;
+			*)
+			    shift ;;
+		    esac
+		done
+
 		rectangles=" "
 		SR=$(xrandr --query | grep ' connected' | grep -o '[0-9][0-9]*x[0-9][0-9]*[^ ]*')
 		for RES in $SR; do
@@ -259,12 +289,6 @@ case "$1" in
 		# User supplied Image
 		user_image="$folder/user_image.png"
 
-		# find your resolution so images can be resized to match your screen resolution
-    if [ "$3" == "-r" ] || [ "$3" == "--resolution" ]; then
-      y_res=$4
-    else
-  		y_res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
-    fi
 		# create folder
 		if [ ! -d $folder ]; then
 			echo "Creating '$folder' directory to cache processed images."
@@ -272,7 +296,7 @@ case "$1" in
 		fi
 
 		# get random file in dir if passed argument is a dir
-		rec_get_random "$2"
+		rec_get_random "$background"
 
 		# get user image
 		cp "$user_input" "$user_image"
@@ -301,10 +325,22 @@ case "$1" in
 		convert "$resized" -fill black -colorize 40% "$dim"
 
 		# blur
-		convert "$resized" -blur 0x5 "$blur"
+		blur_shrink=$(echo "scale=2; 20 / $blur_level" | bc)
+		blur_sigma=$(echo "scale=2; 0.6 * $blur_level" | bc)
+		convert "$resized" \
+		    -filter Gaussian \
+		    -resize "$blur_shrink%" \
+		    -define "filter:sigma=$blur_sigma" \
+		    -resize "$y_res^" -gravity center -extent "$y_res" \
+		    "$blur"
 
 		# dimblur
-		convert "$dim" -blur 0x5 "$dimblur"
+		convert "$dim" \
+		    -filter Gaussian \
+		    -resize "$blur_shrink%" \
+		    -define "filter:sigma=$blur_sigma" \
+		    -resize "$y_res^" -gravity center -extent "$y_res" \
+		    "$dimblur"
 
 		# lockscreen backgrounds
 


### PR DESCRIPTION
Replace gaussian blur with shrinking and scaling the image. Adjust the shrinking and scaling factors based on a number set by the user. The default blur level should keep the blur about the same. 

This new blur method also speeds up the blurring. The default settings see a speedup of ~4 seconds on my machine, even better for higher blur factors. 

This adds a dependency on `bc`.