### PR TITLE
Lock before suspend to prevent race

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -42,7 +42,7 @@ lock() {
 	background=00000000
 	foreground=ffffffff
 	i3lock \
-		-t -n -i "$1" \
+		-t -i "$1" \
 		--timepos="x-90:h-ch+30" \
 		--datepos="tx+24:ty+25" \
 		--clock --datestr "Type password to unlock..." \
@@ -206,28 +206,28 @@ case "$1" in
 			"")
 				# default lockscreen
 				prelock
-				systemctl suspend && lock "$l_resized"
+				lock "$l_resized" && systemctl suspend
 				postlock
 				;;
 
 			dim)
 				# lockscreen with dimmed background
 				prelock
-				systemctl suspend && lock "$l_dim"
+				lock "$l_dim" && systemctl suspend
 				postlock
 				;;
 
 			blur)
 				# set lockscreen with blurred background
 				prelock
-				systemctl suspend && lock "$l_blur"
+				lock "$l_blur" && systemctl suspend
 				postlock
 				;;
 
 			dimblur)
 				# set lockscreen with dimmed + blurred background
 				prelock
-				systemctl suspend && lock "$l_dimblur"
+				lock "$l_dimblur" && systemctl suspend
 				postlock
 				;;
 		esac


### PR DESCRIPTION
For suspend to work consistently, the screen must be locked before the suspend. Otherwise, occasionally the suspend will occur before the screen locks, resulting in a wakeup to a momentarily unlocked screen.

This patch removes the "`-n` (`--nofork`)" flag from the i3lock invocation. i3lock Forking is useful because it allows locking to properly occur before the suspend, as in this patch and as described in the i3lock-color man page:

> i3lock forks, so you can combine it with an alias to suspend  to  RAM (run  "i3lock  && echo mem > /sys/power/state" to get a locked screen after waking up your computer from suspend to RAM)


Was there a reason for enabling nofork? If so, this patch can be reworked to fix the problem in another way.