### PR TITLE
Changes how the rectangle opacity is rendered

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -353,16 +353,16 @@ case "$1" in
 		echo
 		echo "Caching images for faster screen locking"
 		# resized
-		convert "$resized" -draw "fill black fill-opacity 0.4 $rectangles" "$l_resized"
+		convert "$resized" -draw "fill '#00000096' $rectangles" "$l_resized"
 
 		# dim
-		convert "$dim" -draw "fill black fill-opacity 0.4 $rectangles" "$l_dim"
+		convert "$dim" -draw "fill '#00000096' $rectangles" "$l_dim"
 
 		# blur
-		convert "$blur" -draw "fill black fill-opacity 0.4 $rectangles" "$l_blur"
+		convert "$blur" -draw "fill '#00000096' $rectangles" "$l_blur"
 
 		# blur
-		convert "$dimblur" -draw "fill black fill-opacity 0.4 $rectangles" "$l_dimblur"
+		convert "$dimblur" -draw "fill '#00000096' $rectangles" "$l_dimblur"
 
 		echo
 		echo "All required changes have been applied"


### PR DESCRIPTION
For some reasons, the rectangle at the bottom left of my lock screen was opaque.

`fill-opacity 0.4` is used to change the opacity, but I was unable to find documentation about this function. I changed it to use the default fill with an hex color with an opacity of 0.4.

I'm using 
```
Version: ImageMagick 7.0.7-28 Q16 x86_64 2018-03-31 http://www.imagemagick.org
Copyright: © 1999-2018 ImageMagick Studio LLC
License: http://www.imagemagick.org/script/license.php
Features: Cipher DPC HDRI Modules OpenCL OpenMP
Delegates (built-in): bzlib cairo fontconfig freetype gslib jng jp2 jpeg lcms lqr ltdl lzma openexr pangocairo png ps raw rsvg tiff webp wmf x xml zlib
```