### PR TITLE
Don't base directory name on resolution parameter

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -8,7 +8,7 @@
 res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
 
 init_filenames() {
-	#$1 resolution
+	#$1 dimensions
 
 	# create folder in ~/.cache/i3lock directory
 	folder="$HOME/.cache/i3lock/$1"
@@ -249,7 +249,6 @@ case "$1" in
 			case "$1" in
 			-r | --resolution )
 				res="$2"
-				init_filenames $res
 				shift 2
 				;;
 			-b | --blur )


### PR DESCRIPTION
This makes it possible to scale images to the desired resolution also
for multi-monitor setups.

For instance, if you have 2 1920x1200 monitors side by side, the
"dimensions directory" will be named `~/.cache/i3lock/3840x1200/`, but
you can still scale the images to 1920x1200 by supplying a
`-r 1920x1200` argument to `betterlockscreen -u`. This results in a
background image that is not stretched out over both monitors, but
instead the single image is duplicated and made to fit each monitor.

Of course, this only works if both monitors have the same resolution.