### PR TITLE
Add support for HiDPI screens

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -123,7 +123,7 @@ lockselect() {
 logical_px() {
 	# get dpi value from xrdb
 	local DPI=$(xrdb -query | awk '/Xft.dpi/ {print $2}')
-	local SCALE=$(echo "scale=2; 150 / 96.0" | bc)
+	local SCALE=$(echo "scale=2; $DPI / 96.0" | bc)
 
 	# check if scaling the value is worthy
 	if [ $(echo "$SCALE > 1.25" | bc -l) -eq 0 ]; then

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -125,7 +125,7 @@ logical_px() {
 	local DPI=$(xrdb -query | awk '/Xft.dpi/ {print $2}')
 	
 	# return the default value if no DPI is set
-	if [ -z "$DPI"]; then
+	if [ -z "$DPI" ]; then
 		echo $1
 	else
 		local SCALE=$(echo "scale=2; $DPI / 96.0" | bc)

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -120,6 +120,18 @@ lockselect() {
 	postlock
 }
 
+logical_px() {
+	# get dpi value from xrdb
+	local DPI=$(xrdb -query | awk '/Xft.dpi/ {print $2}')
+	local SCALE=$(echo "scale=2; 150 / 96.0" | bc)
+
+	# check if scaling the value is worthy
+	if [ $(echo "$SCALE > 1.25" | bc -l) -eq 0 ]; then
+		echo $1
+	else
+		echo "$SCALE * $1 / 1" | bc
+	fi
+}
 
 update() {
 	# use 
@@ -132,9 +144,9 @@ update() {
 	SR=$(xrandr --query | grep ' connected' | grep -o '[0-9][0-9]*x[0-9][0-9]*[^ ]*')
 	for RES in $SR; do
 		SRA=(${RES//[x+]/ })
-		CX=$((${SRA[2]} + 25))
-		CY=$((${SRA[1]} - 30))
-		rectangles+="rectangle $CX,$CY $((CX+300)),$((CY-80)) "
+		CX=$((${SRA[2]} + $(logical_px 25)))
+		CY=$((${SRA[1]} - $(logical_px 30)))
+		rectangles+="rectangle $CX,$CY $((CX+$(logical_px 300))),$((CY-$(logical_px 80))) "
 	done
 
 	# User supplied Image

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -123,13 +123,19 @@ lockselect() {
 logical_px() {
 	# get dpi value from xrdb
 	local DPI=$(xrdb -query | awk '/Xft.dpi/ {print $2}')
-	local SCALE=$(echo "scale=2; $DPI / 96.0" | bc)
-
-	# check if scaling the value is worthy
-	if [ $(echo "$SCALE > 1.25" | bc -l) -eq 0 ]; then
+	
+	# return the default value if no DPI is set
+	if [ -z "$DPI"]; then
 		echo $1
 	else
-		echo "$SCALE * $1 / 1" | bc
+		local SCALE=$(echo "scale=2; $DPI / 96.0" | bc)
+
+		# check if scaling the value is worthy
+		if [ $(echo "$SCALE > 1.25" | bc -l) -eq 0 ]; then
+			echo $1
+		else
+			echo "$SCALE * $1 / 1" | bc
+		fi
 	fi
 }
 


### PR DESCRIPTION
Hi,

I recently faced #42 but unfortunately I'm not here to bring you the ultimate answer answer to  life, the universe and everything.

However, I have a working solution to adapt betterlockscreen to HiDPI screens. This fix read the DPI value from `Xft.dpi` and use it to compute the best rectangle size. The function `logical_px()` was inspired by [this one from i3lock](https://github.com/i3/i3lock/blob/master/dpi.c#L93).