### PR TITLE
Add support to change default font

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -31,6 +31,7 @@ init_filenames() {
 	    timecolor=ffffffff
 	    datecolor=ffffffff
 	    loginbox=00000066
+	    font="sans-serif"
 	fi
 
 	# create folder in ~/.cache/i3lock directory
@@ -87,6 +88,7 @@ lock() {
 		--ringvercolor=$ringvercolor --ringwrongcolor=$ringwrongcolor --indpos='x+280:h-70' \
 		--radius=20 --ring-width=4 --veriftext='' --wrongtext='' \
 		--verifcolor="$verifcolor" --timecolor="$timecolor" --datecolor="$datecolor" \
+		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" --greeter-font="$font" \
 		--noinputtext='' --force-clock $lockargs
 }
 


### PR DESCRIPTION
Because the default is to use the `sans-serif` alias, which could be mapped to a font not displaying correctly (eg. Noto Color Emoji on my config).