### PR TITLE
Transparent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Most of i3lock wrapper scripts out there takes an image, adds some effect and lo
 adding effects, overall experience doesn't feel natural given delay of 2-3 seconds.
 Who would like a delay of 2-3 seconds while locking screen?
 
-So betterlockscreen was my attempt to solve this problem, as we dont need to change lockscreen background frequently
+So betterlockscreen was my attempt to solve this problem, as we don't need to change lockscreen background frequently
 this script caches images with effect so overall experience is simple and as fast as native i3lock.
 
 ### How it works
@@ -48,7 +48,8 @@ images as lockscreen background depending on argument provided by user.
 
 - [i3lock-color](https://github.com/PandorasFox/i3lock-color) - i3lock fork with additional features( >= 2.11-c )
 - [imagemagick](https://www.imagemagick.org/script/index.php) - To apply effects to images
-- [xdpyinfo](https://www.x.org/archive/X11R7.7/doc/man/man1/xdpyinfo.1.xhtml), [xrandr](https://www.x.org/wiki/Projects/XRandR/), [bc](https://www.gnu.org/software/bc/) and [feh](https://feh.finalrewind.org/) - To find screen resolution, set custom blur level and wallpaper handling.
+- [scrot](https://tracker.debian.org/pkg/scrot) - For live (transparent lockscreen) mode
+- [xdpyinfo](https://www.x.org/archive/X11R7.7/doc/man/man1/xdpyinfo.1.xhtml), [xrandr](https://www.x.org/wiki/Projects/XRandR/), [bc](https://www.gnu.org/software/bc/), and [feh](https://feh.finalrewind.org/) - To find screen resolution, set custom blur level and wallpaper handling.
 
 ### Installation
 
@@ -81,7 +82,7 @@ export PATH="${PATH}:${HOME}/.local/bin/"
 
 ###### Installing dependencies(not required if using betterlockscreen aur package)
 
-`pacman -S imagemagick feh xorg-xrandr xorg-xdpyinfo`
+`pacman -S imagemagick feh xorg-xrandr xorg-xdpyinfo scrot`
 
 - i3lock-color - `trizen -S i3lock-color`
 
@@ -113,7 +114,7 @@ cp /usr/share/doc/betterlockscreen/examples/betterlockscreenrc ~/.config
 Run `betterlockscreen` and point it to either a directory (`betterlockscreen -u "path/to/dir"`) or an image (`betterlockscreen -u "/path/to/img.jpg"`) and that's all. `betterlockscreen` will change update its cache with image you provided.
 
 ```sh
-usage: betterlockscreen [-u "path/to/img.jpg"] [-l "dim, blur or dimblur"]
+usage: betterlockscreen [-u "path/to/img.jpg"] [-l "dim, blur or dimblur"] -L
            [-w "dim, blur, pixel or dimblur"] [-t "custom text"] [-s "lockscreen and suspend"]
 					 [-r "resolution"] [-b "factor"]
 
@@ -125,6 +126,9 @@ required:
 usage:
 	-l, --lock effect-name
 			locks with provided effect
+	-L, --live
+			enables live (transparent lockscreen) mode
+			NOTE: This significantly decreases performance
 	-w, --wall effect-name
 			set desktop background with provided effect
 	-s, --suspend effect-name
@@ -143,20 +147,23 @@ usage:
 
 Usage examples:
 1. Updating image cache(required)
-betterlockscreen -u ~/Pictures/Forests.png # caches given image
-betterlockscreen -u ~/Pictures             # caches random image from ~/Pictures directory
+betterlockscreen -u ~/Pictures/Forests.png	# caches given image
+betterlockscreen -u ~/Pictures				# caches random image from ~/Pictures directory
 
 2. Custom resolution and blur range
 betterlockscreen -u path/to/directory -r 1920x1080 -b 0.5
 
 3. Lockscreen
-betterlockscreen -l dim                    # lockscreen with dim effect
+betterlockscreen -l dim						# lockscreen with dim effect
 
 4. Lockscreen with custom text
 betterlockscreen -l pixel -t "custom lockscreen text"
 
 5. Set desktop background
-betterlockscreen -w blur                   # set desktop background with blur effect
+betterlockscreen -w blur					# set desktop background with blur effect
+
+6. Enable live mode
+betterlockscreen -l dimblur -L				# transparent lockscreen
 ```
 
 ### Set desktop background on startup

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Run `betterlockscreen` and point it to either a directory (`betterlockscreen -u 
 
 ```sh
 usage: betterlockscreen [-u "path/to/img.jpg"] [-l "dim, blur or dimblur"]
-           [-w "dim, blur, or dimblur"] [-t "custom text"] [-s "lockscreen and suspend"]
+           [-w "dim, blur, pixel or dimblur"] [-t "custom text"] [-s "lockscreen and suspend"]
 					 [-r "resolution"] [-b "factor"]
 
 betterlockscreen - faster and sweet looking lockscreen for linux systems.
@@ -131,7 +131,7 @@ usage:
 			lockscreen and suspend
 
 			Available effects:
-				dim, blur or dimblur
+				dim, blur, pixel or dimblur
 
 	-t, --text "custom text"
 			set custom lockscreen text
@@ -153,7 +153,7 @@ betterlockscreen -u path/to/directory -r 1920x1080 -b 0.5
 betterlockscreen -l dim                    # lockscreen with dim effect
 
 4. Lockscreen with custom text
-betterlockscreen -l dim -t "custom lockscreen text"
+betterlockscreen -l pixel -t "custom lockscreen text"
 
 5. Set desktop background
 betterlockscreen -w blur                   # set desktop background with blur effect

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -372,6 +372,14 @@ usage() {
 	echo '		to set custom lockscreen text (max 31 chars)'
 	echo "		E.g: betterlockscreen -l dim -t \"Don't touch my machine!\""
 	echo '		E.g: betterlockscreen --text "Hi, user!" -s blur'
+	echo
+	echo
+	echo '	-S --screen'
+	echo '		specifies what screen the lock will appear on.'
+	echo '		the lock screen will appear on all monitors by default.'
+	echo '		this number is 0 indexed and depends on libxinenrama.'
+	echo '		E.g: betterlockscreen -l dim -S 1'
+	echo '		E.g: betterlockscreen -l blur --screen 0'
 }
 
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -81,6 +81,33 @@ prelock() {
 }
 
 
+livebg() {
+	# takes screenshot
+	scroto=/tmp/betterlockscreenscrot.png
+	scrot $scroto
+
+	# applies effect to screenshot
+	case "$2" in
+		blur)
+			blur $scroto $liveimgeffect
+			;;
+
+		dim)
+			dim $scroto $liveimgeffect
+			;;
+
+		dimblur)
+			dimblur $scroto $liveimgeffect
+			;;
+
+		pixel)
+			pixel $scroto $liveimgeffect
+			;;
+	esac
+
+	composite $compoverlay $liveimgeffect $tmpimg
+}
+
 lock() {
 	# $1 is the image path
 	# $2 is the lock effect

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -7,21 +7,6 @@
 # find your resolution so images can be resized to match your screen resolution
 res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
 
-# parses and displays battery info using /sys/class/power_supply/BAT0/uevent
-bat_info() {
-	bat_info=$(cat /sys/class/power_supply/BAT0/uevent)
-
-	# iterates through each line of /sys/class/power_supply/BAT0/uevent and sets bat_status and bat_level
-	for x in $bat_info; do
-		if [[ grep "POWER_SUPPLY_STATUS" <<< x ]]; then
-			bat_status=$(awk -F = '{print $2}')
-		fi
-		if [[ grep "POWER_SUPPLY_CAPACITY" <<< x ]]; then
-			bat_level=$(awk -F = '{print $2}')
-		fi
-	done
-}
-
 init_filenames() {
 	#$1 resolution
 
@@ -184,9 +169,6 @@ update() {
 
 	# default blur level; fallback to 1
 	[[ $blur_level ]] || blur_level=1
-
-	# show battery info is false by default
-	[[ $show_bat_info ]] || show_bat_info=false
 
 	rectangles=" "
 	SR=$(xrandr --query | grep ' connected' | grep -o '[0-9][0-9]*x[0-9][0-9]*[^ ]*')
@@ -386,13 +368,6 @@ usage() {
 	echo '		E.g: betterlockscreen -u path/to/image.png --blur 0.5'
 	echo
 	echo
-	echo '	-B --battery-info'
-	echo '		to be used after -u'
-	echo '		toggles battery information. Default to false.'
-	echo '		E.g: betterlockscreen -u path/to/image.png -B true'
-	echo '		E.g: betterlockscreen -u path/to/image.png --battery-info true'
-	echo
-	echo
 	echo '	-t --text'
 	echo '		to set custom lockscreen text (max 31 chars)'
 	echo "		E.g: betterlockscreen -l dim -t \"Don't touch my machine!\""
@@ -441,16 +416,6 @@ for arg in "$@"; do
 		-r | --resolution)
 			res="$2"
 			init_filenames $res force
-			shift 2
-			;;
-
-		-b | --blur)
-			blur_level="$2"
-			shift 2
-			;;
-
-		-B | --battery-info)
-			show_bat_info="$2"
 			shift 2
 			;;
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -270,7 +270,6 @@ update() {
 	echo 'All required changes have been applied'
 }
 
-
 wallpaper() {
 	case "$1" in
 		'')
@@ -378,6 +377,13 @@ usage() {
 	echo '		E.g: betterlockscreen -u path/to/image.png --blur 0.5'
 	echo
 	echo
+	echo '	-L --live'
+	echo '		to be used after -l'
+	echo '		used to make lock background the current screen.'
+	echo '		E.g: betterlockscreen -l blur -L'
+	echo '		E.g: betterlockscreen -l pixel --live'
+	echo
+	echo
 	echo '	-t --text'
 	echo '		to set custom lockscreen text (max 31 chars)'
 	echo "		E.g: betterlockscreen -l dim -t \"Don't touch my machine!\""
@@ -431,6 +437,11 @@ for arg in "$@"; do
 
 		-b | --blur)
 			blur_level="$2"
+			shift 2
+			;;
+
+		-L | --live)
+			livebg=true
 			shift 2
 			;;
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -82,7 +82,32 @@ prelock() {
 
 
 lock() {
-	#$1 image path
+	# $1 is the image path
+	# $2 is the lock effect
+
+	if [[ $livebgimg ]]; then
+		case "$2" in
+			blur)
+				livebg "blur"
+				;;
+
+			dim)
+				livebg "dim"
+				;;
+
+			dimblur)
+				livebg "dimblur"
+				;;
+
+			pixel)
+				livebg "pixel"
+				;;
+		esac
+
+		lockbg=$tmpimg
+	else
+		lockbg=$1
+	fi
 
 	i3lock \
 		-t -i "$1" \
@@ -101,7 +126,7 @@ lock() {
 
 
 postlock() {
-	if [ ! -z "$(pidof dunst)" ] ; then
+	if [ ! -z "$(pidof dunst)" ]; then
 		pkill -u "$USER" -USR2 dunst
 	fi
 }
@@ -124,27 +149,27 @@ lockselect() {
 	case "$1" in
 		dim)
 			# lockscreen with dimmed background
-			lock "$l_dim"
+			lock "$l_dim" $1
 			;;
 
 		blur)
 			# set lockscreen with blurred background
-			lock "$l_blur"
+			lock "$l_blur" $1
 			;;
 
 		dimblur)
 			# set lockscreen with dimmed + blurred background
-			lock "$l_dimblur"
+			lock "$l_dimblur" $1
 			;;
 
 		pixel)
 			# set lockscreen with pixelated background
-			lock "$l_pixel"
+			lock "$l_pixel" $1
 			;;
 
 		*)
 			# default lockscreen
-			lock "$l_resized"
+			lock "$l_resized" $1
 			;;
 	esac
 	postlock
@@ -167,6 +192,50 @@ logical_px() {
 			echo "$SCALE * $1 / 1" | bc
 		fi
 	fi
+}
+
+# blur
+blur() {
+	# $1 is image to be blurred
+	# $2 is output
+
+	blur_shrink=$(echo "scale=2; 20 / $blur_level" | bc)
+	blur_sigma=$(echo "scale=2; 0.6 * $blur_level" | bc)
+	convert "$1" \
+		-filter Gaussian \
+		-resize "$blur_shrink%" \
+		-define "filter:sigma=$blur_sigma" \
+		-resize "$res^" -gravity center -extent "$res" \
+		"$2"
+}
+
+# pixelate
+pixel() {
+	# $1 is image to be pixelated
+	# $2 is ouput
+
+	convert -scale 10% -scale 1000% "$1" "$pixel"
+}
+
+# dim
+dim() {
+	# $1 is image to be dimmed
+	# $2 is ouput
+
+	convert "$1" -fill black -colorize 40% "$2"
+}
+
+# dimblur
+dimblur() {
+	# $1 is image to be dimblurred
+	# $2 is ouput
+
+	convert "$1" \
+		-filter Gaussian \
+		-resize "$blur_shrink%" \
+		-define "filter:sigma=$blur_sigma" \
+		-resize "$res^" -gravity center -extent "$res" \
+		"$2"
 }
 
 update() {
@@ -221,28 +290,17 @@ update() {
 	echo
 	echo 'Applying dim, blur, and pixelation effect to resized image'
 	# dim
-	convert "$resized" -fill black -colorize 40% "$dim"
+	dim $resized $dim
 
 	# pixel
-	convert -scale 10% -scale 1000% "$resized" "$pixel"
+	pixel $resized $pixel
 
 	# blur
-	blur_shrink=$(echo "scale=2; 20 / $blur_level" | bc)
-	blur_sigma=$(echo "scale=2; 0.6 * $blur_level" | bc)
-	convert "$resized" \
-		-filter Gaussian \
-		-resize "$blur_shrink%" \
-		-define "filter:sigma=$blur_sigma" \
-		-resize "$res^" -gravity center -extent "$res" \
-		"$blur"
+	blur $resized $blur
 
 	# dimblur
-	convert "$dim" \
-		-filter Gaussian \
-		-resize "$blur_shrink%" \
-		-define "filter:sigma=$blur_sigma" \
-		-resize "$res^" -gravity center -extent "$res" \
-		"$dimblur"
+	dim $resized $dim
+	blur $dim $dimblur
 
 	# lockscreen backgrounds
 
@@ -441,7 +499,7 @@ for arg in "$@"; do
 			;;
 
 		-L | --live)
-			livebg=true
+			livebgimg=true
 			shift 2
 			;;
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -137,7 +137,7 @@ lock() {
 	fi
 
 	i3lock \
-		-t -i "$1" \
+		-t -i "$lockbg" \
 		--timepos='x+110:h-70' \
 		--datepos='x+43:h-45' \
 		--clock --date-align 1 --datestr "$locktext" \
@@ -465,6 +465,7 @@ usage() {
 	echo '	-L --live'
 	echo '		to be used after -l'
 	echo '		used to make lock background the current screen.'
+	echo '		Note: slower due to not using cached image.'
 	echo '		E.g: betterlockscreen -l blur -L'
 	echo '		E.g: betterlockscreen -l pixel --live'
 	echo

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -31,6 +31,8 @@ init_filenames() {
 	    timecolor=ffffffff
 	    datecolor=ffffffff
 	    loginbox=00000066
+		font="sans-serif"
+      	locktext='Type password to unlock...'
 	fi
 
 	# create folder in ~/.cache/i3lock directory
@@ -89,6 +91,7 @@ lock() {
 		--ringvercolor=$ringvercolor --ringwrongcolor=$ringwrongcolor --indpos='x+280:h-70' \
 		--radius=20 --ring-width=4 --veriftext='' --wrongtext='' \
 		--verifcolor="$verifcolor" --timecolor="$timecolor" --datecolor="$datecolor" \
+		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
 		--noinputtext='' --force-clock $lockargs
 }
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -6,6 +6,8 @@
 
 # find your resolution so images can be resized to match your screen resolution
 res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
+locktext='Type password to unlock...'
+
 
 init_filenames() {
 	#$1 resolution
@@ -29,8 +31,6 @@ init_filenames() {
 	    timecolor=ffffffff
 	    datecolor=ffffffff
 	    loginbox=00000066
-	    font="sans-serif"
-      locktext='Type password to unlock...'
 	fi
 
 	# create folder in ~/.cache/i3lock directory
@@ -55,12 +55,14 @@ init_filenames() {
 	dim="$folder/dim.png" # image with subtle overlay of black
 	blur="$folder/blur.png" # blurred version
 	dimblur="$folder/dimblur.png"
+	pixel="$folder/pixel.png" # pixelated image
 
 	# lockscreen images (images to be used as lockscreen background)
 	l_resized="$folder/l_resized.png"
 	l_dim="$folder/l_dim.png"
 	l_blur="$folder/l_blur.png"
 	l_dimblur="$folder/l_dimblur.png"
+	l_pixel="$folder/l_pixel.png"
 }
 
 init_filenames $res
@@ -87,7 +89,6 @@ lock() {
 		--ringvercolor=$ringvercolor --ringwrongcolor=$ringwrongcolor --indpos='x+280:h-70' \
 		--radius=20 --ring-width=4 --veriftext='' --wrongtext='' \
 		--verifcolor="$verifcolor" --timecolor="$timecolor" --datecolor="$datecolor" \
-		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
 		--noinputtext='' --force-clock $lockargs
 }
 
@@ -129,6 +130,11 @@ lockselect() {
 			lock "$l_dimblur"
 			;;
 
+		pixel)
+			# set lockscreen with pixelated background
+			lock "$l_pixel"
+			;;
+
 		*)
 			# default lockscreen
 			lock "$l_resized"
@@ -140,7 +146,7 @@ lockselect() {
 logical_px() {
 	# get dpi value from xrdb
 	local DPI=$(xrdb -query | awk '/Xft.dpi/ {print $2}')
-
+	
 	# return the default value if no DPI is set
 	if [ -z "$DPI" ]; then
 		echo $1
@@ -157,7 +163,7 @@ logical_px() {
 }
 
 update() {
-	# use
+	# use 
 	background="$1"
 
 	# default blur level; fallback to 1
@@ -206,9 +212,12 @@ update() {
 	convert "$orig_wall" -resize "$res""^" -gravity center -extent "$res" "$resized"
 
 	echo
-	echo 'Applying dim and blur effect to resized image'
+	echo 'Applying dim, blur, and pixelation effect to resized image'
 	# dim
 	convert "$resized" -fill black -colorize 40% "$dim"
+
+	# pixel
+	convert -scale 10% -scale 1000% "$resized" "$pixel"
 
 	# blur
 	blur_shrink=$(echo "scale=2; 20 / $blur_level" | bc)
@@ -241,8 +250,11 @@ update() {
 	# blur
 	convert "$blur" -draw "fill #$loginbox $rectangles" "$l_blur"
 
-	# blur
+	# dimblur
 	convert "$dimblur" -draw "fill #$loginbox $rectangles" "$l_dimblur"
+
+	# pixel
+	convert "$pixel" -draw "fill #$loginbox $rectangles" "$l_pixel"
 	echo
 	echo 'All required changes have been applied'
 }
@@ -268,6 +280,11 @@ wallpaper() {
 		dimblur)
 			# set dimmed + blurred image as wallpaper
 			feh --bg-fill $dimblur
+			;;
+
+		pixel)
+			# set pixelated image as wallpaper
+			feh --bg-fill $pixel
 			;;
 	esac
 }

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -6,8 +6,21 @@
 
 # find your resolution so images can be resized to match your screen resolution
 res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
-locktext='Type password to unlock...'
 
+# parses and displays battery info using /sys/class/power_supply/BAT0/uevent
+bat_info() {
+	bat_info=$(cat /sys/class/power_supply/BAT0/uevent)
+
+	# iterates through each line of /sys/class/power_supply/BAT0/uevent and sets bat_status and bat_level
+	for x in $bat_info; do
+		if [[ grep "POWER_SUPPLY_STATUS" <<< x ]]; then
+			bat_status=$(awk -F = '{print $2}')
+		fi
+		if [[ grep "POWER_SUPPLY_CAPACITY" <<< x ]]; then
+			bat_level=$(awk -F = '{print $2}')
+		fi
+	done
+}
 
 init_filenames() {
 	#$1 resolution
@@ -171,6 +184,9 @@ update() {
 
 	# default blur level; fallback to 1
 	[[ $blur_level ]] || blur_level=1
+
+	# show battery info is false by default
+	[[ $show_bat_info ]] || show_bat_info=false
 
 	rectangles=" "
 	SR=$(xrandr --query | grep ' connected' | grep -o '[0-9][0-9]*x[0-9][0-9]*[^ ]*')
@@ -370,6 +386,13 @@ usage() {
 	echo '		E.g: betterlockscreen -u path/to/image.png --blur 0.5'
 	echo
 	echo
+	echo '	-B --battery-info'
+	echo '		to be used after -u'
+	echo '		toggles battery information. Default to false.'
+	echo '		E.g: betterlockscreen -u path/to/image.png -B true'
+	echo '		E.g: betterlockscreen -u path/to/image.png --battery-info true'
+	echo
+	echo
 	echo '	-t --text'
 	echo '		to set custom lockscreen text (max 31 chars)'
 	echo "		E.g: betterlockscreen -l dim -t \"Don't touch my machine!\""
@@ -423,6 +446,11 @@ for arg in "$@"; do
 
 		-b | --blur)
 			blur_level="$2"
+			shift 2
+			;;
+
+		-B | --battery-info)
+			show_bat_info="$2"
 			shift 2
 			;;
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -57,6 +57,12 @@ init_filenames() {
 	dimblur="$folder/dimblur.png"
 	pixel="$folder/pixel.png" # pixelated image
 
+	# composite overlay for live desktop effects
+	compoverlay="$folder/compoverlay.png"
+
+	# temporary image for for live desktop effects
+	tmpimg="/tmp/betterlockscreentmp.png"
+
 	# lockscreen images (images to be used as lockscreen background)
 	l_resized="$folder/l_resized.png"
 	l_dim="$folder/l_dim.png"
@@ -256,6 +262,10 @@ update() {
 
 	# pixel
 	convert "$pixel" -draw "fill #$loginbox $rectangles" "$l_pixel"
+
+	# composite overlay
+	convert -size "$res" xc:none -draw "fill #$loginbox $rectangles" "$compoverlay" 
+
 	echo
 	echo 'All required changes have been applied'
 }

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -372,14 +372,6 @@ usage() {
 	echo '		to set custom lockscreen text (max 31 chars)'
 	echo "		E.g: betterlockscreen -l dim -t \"Don't touch my machine!\""
 	echo '		E.g: betterlockscreen --text "Hi, user!" -s blur'
-	echo
-	echo
-	echo '	-S --screen'
-	echo '		specifies what screen the lock will appear on.'
-	echo '		the lock screen will appear on all monitors by default.'
-	echo '		this number is 0 indexed and depends on libxinenrama.'
-	echo '		E.g: betterlockscreen -l dim -S 1'
-	echo '		E.g: betterlockscreen -l blur --screen 0'
 }
 
 
@@ -424,6 +416,11 @@ for arg in "$@"; do
 		-r | --resolution)
 			res="$2"
 			init_filenames $res force
+			shift 2
+			;;
+
+		-b | --blur)
+			blur_level="$2"
 			shift 2
 			;;
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -82,30 +82,44 @@ prelock() {
 
 
 livebg() {
+	# $1 is blur effect
+
 	# takes screenshot
-	scroto=/tmp/betterlockscreenscrot.png
+	scroto="/tmp/betterlockscreenscrot.png"
 	scrot $scroto
 
+	liveimgeffect="/tmp/betterlockscreeneffect.png"
+
 	# applies effect to screenshot
-	case "$2" in
+	case "$1" in
+		# combines the overlay with the lock effect
 		blur)
 			blur $scroto $liveimgeffect
+			composite "$compoverlay" "$liveimgeffect" "$tmpimg"
 			;;
 
 		dim)
 			dim $scroto $liveimgeffect
+			composite "$compoverlay" "$liveimgeffect" "$tmpimg"
 			;;
 
 		dimblur)
 			dimblur $scroto $liveimgeffect
+			composite "$compoverlay" "$liveimgeffect" "$tmpimg"
 			;;
 
 		pixel)
 			pixel $scroto $liveimgeffect
+			composite "$compoverlay" "$liveimgeffect" "$tmpimg"
 			;;
+
+		*)
+			composite "$compoverlay" "$scroto" "$tmpimg"
+			;;
+
 	esac
 
-	composite $compoverlay $liveimgeffect $tmpimg
+	rm "$scroto" $(ls "$liveimgeffect" 2> /dev/null)
 }
 
 lock() {
@@ -128,6 +142,10 @@ lock() {
 
 			pixel)
 				livebg "pixel"
+				;;
+
+			*)
+				livebg
 				;;
 		esac
 
@@ -156,6 +174,9 @@ postlock() {
 	if [ ! -z "$(pidof dunst)" ]; then
 		pkill -u "$USER" -USR2 dunst
 	fi
+
+	# Remove tmp images
+	[[ $livebgimg ]] && $(rm "$tmpimg")
 }
 
 
@@ -239,15 +260,15 @@ blur() {
 # pixelate
 pixel() {
 	# $1 is image to be pixelated
-	# $2 is ouput
+	# $2 is output
 
-	convert -scale 10% -scale 1000% "$1" "$pixel"
+	convert "$1" -scale 10% -scale 1000% "$2"
 }
 
 # dim
 dim() {
 	# $1 is image to be dimmed
-	# $2 is ouput
+	# $2 is output
 
 	convert "$1" -fill black -colorize 40% "$2"
 }
@@ -255,22 +276,19 @@ dim() {
 # dimblur
 dimblur() {
 	# $1 is image to be dimblurred
-	# $2 is ouput
+	# $2 is output
 
-	convert "$1" \
-		-filter Gaussian \
-		-resize "$blur_shrink%" \
-		-define "filter:sigma=$blur_sigma" \
-		-resize "$res^" -gravity center -extent "$res" \
-		"$2"
+	dim $1 $dim
+	blur $dim $2
 }
+
 
 update() {
 	# use 
 	background="$1"
 
 	# default blur level; fallback to 1
-	[[ $blur_level ]] || blur_level=1
+	# [[ $blur_level ]] || blur_level=1
 
 	rectangles=" "
 	SR=$(xrandr --query | grep ' connected' | grep -o '[0-9][0-9]*x[0-9][0-9]*[^ ]*')
@@ -326,8 +344,7 @@ update() {
 	blur $resized $blur
 
 	# dimblur
-	dim $resized $dim
-	blur $dim $dimblur
+	dimblur $resized $dimblur
 
 	# lockscreen backgrounds
 
@@ -349,7 +366,8 @@ update() {
 	convert "$pixel" -draw "fill #$loginbox $rectangles" "$l_pixel"
 
 	# composite overlay
-	convert -size "$res" xc:none -draw "fill #$loginbox $rectangles" "$compoverlay" 
+	convert -size "$res" xc:none "$compoverlay"
+	convert "$compoverlay" -draw "fill #$loginbox $rectangles" "$compoverlay"
 
 	echo
 	echo 'All required changes have been applied'
@@ -542,6 +560,9 @@ for arg in "$@"; do
 			;;
 	esac
 done
+
+# if blur_level isn't specified fallback to 1
+[[ $blur_level ]] || blur_level=1
 
 # Run image generation
 [[ $runupdate ]] && update "$imagepath"


### PR DESCRIPTION
I added an optional transparent argument. Transparent mode turns your lockscreen invisible. This mode is fully compatible with effects too. While this does add a significant decrease in speed, it only slows down the lock process if the argument is specified. 

**How it works:**

betterlockscreen -u */file/path/img* **-**
Caches a transparent overlay of the black rectangle.

betterlockscreen -l *effect-name*  -L **-**
Takes a screenshot and applies the desired effect to it. ImageMagick then composites the overlay onto it.

**TODO:**
- Speed up locking. This adds lag to the lock process; mostly due to applying the effects.