### PR TITLE
Automatically deduce DPI

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -144,9 +144,11 @@ lockselect() {
 	postlock
 }
 
+# $1: number of pixels to convert
+# $2: 1 for width. 2 for height
 logical_px() {
 	# get dpi value from xrdb
-	local DPI=$(xrdb -query | awk '/Xft.dpi/ {print $2}')
+	local DPI=$(xdpyinfo | sed -En "s/\s*resolution:\s*([0-9]*)x([0-9]*)\s.*/\\$2/p" | head -n1)
 	
 	# return the default value if no DPI is set
 	if [ -z "$DPI" ]; then
@@ -174,9 +176,9 @@ update() {
 	SR=$(xrandr --query | grep ' connected' | grep -o '[0-9][0-9]*x[0-9][0-9]*[^ ]*')
 	for RES in $SR; do
 		SRA=(${RES//[x+]/ })
-		CX=$((${SRA[2]} + $(logical_px 25)))
-		CY=$((${SRA[1]} - $(logical_px 30)))
-		rectangles+="rectangle $CX,$CY $((CX+$(logical_px 300))),$((CY-$(logical_px 80))) "
+		CX=$((${SRA[2]} + $(logical_px 25 1)))
+		CY=$((${SRA[1]} - $(logical_px 30 2)))
+		rectangles+="rectangle $CX,$CY $((CX+$(logical_px 300 1))),$((CY-$(logical_px 80 2))) "
 	done
 
 	# User supplied Image


### PR DESCRIPTION
With this commit the DPI doesn't have to be listed in the ~/.Xresources and will be deduced automatically.