### PR TITLE
Fix: Allow to remove `current` directory

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -39,6 +39,7 @@ init_filenames() {
 	echo "Got" $@ $res_folder
 	if [ ! -d $folder -o -n "$2" ]; then
 		rm -rf $folder
+		mkdir -p $res_folder
 		ln -s $res_folder $folder
 	fi
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -38,7 +38,7 @@ init_filenames() {
 	folder="$HOME/.cache/i3lock/current"
 	echo "Got" $@ $res_folder
 	if [ ! -d $folder -o -n "$2" ]; then
-		rm -f $folder
+		rm -rf $folder
 		ln -s $res_folder $folder
 	fi
 


### PR DESCRIPTION
I'm constantly getting error that it's unable to remove a directory
```
kamil@desktop:~/.cache/i3lock$ betterlockscreen -u /home/kamil/Documents/wallpapers -u /home/kamil/Documents/wallpapers -r 1920x1080
Got 3840x1200 /home/kamil/.cache/i3lock/3840x1200
Got 1920x1080 force /home/kamil/.cache/i3lock/1920x1080
rm: cannot remove '/home/kamil/.cache/i3lock/current': Is a directory
ln: failed to create symbolic link '/home/kamil/.cache/i3lock/current/1920x1080': File exists
Generating alternate images based on the image you specified,
please wait this might take few seconds...

Converting provided image to match your resolution...

Applying dim, blur, and pixelation effect to resized image

Caching images for faster screen locking

All required changes have been applied
```

My patch should fix it