### PR TITLE
Fix scaling when Xft.dpi are set

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -149,8 +149,11 @@ lockselect() {
 # $2: 1 for width. 2 for height
 logical_px() {
 	# get dpi value from xrdb
-	local DPI=$(xdpyinfo | sed -En "s/\s*resolution:\s*([0-9]*)x([0-9]*)\s.*/\\$2/p" | head -n1)
-	
+	local DPI=$(cat ~/.Xresource | grep -oP 'Xft.dpi:\s*\K\d+' | bc)
+	if [ -z "$DPI" ]; then
+		DPI=$(xdpyinfo | sed -En "s/\s*resolution:\s*([0-9]*)x([0-9]*)\s.*/\\$2/p" | head -n1)
+	fi
+
 	# return the default value if no DPI is set
 	if [ -z "$DPI" ]; then
 		echo $1


### PR DESCRIPTION
When Xft.dpi is set due to HiDPI screen, the rectangle in the lock screen is not calculated to the correct scale.

My fix just simply reads the value of `Xft.dpi` from `~/.Xresource` and then calculates the right `SCALE`.

Not very familiar with shell nor this project, not sure if this is a proper fix, but works fine on my computer.

Fantastic lock screen by the way.