### PR TITLE
Add Timeout Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Run `betterlockscreen` and point it to either a directory (`betterlockscreen -u 
 ```sh
 usage: betterlockscreen [-u "path/to/img.jpg"] [-l "dim, blur or dimblur"]
            [-w "dim, blur, pixel or dimblur"] [-t "custom text"] [-s "lockscreen and suspend"]
-					 [-r "resolution"] [-b "factor"]
+					 [-r "resolution"] [-b "factor"] [--off <timeout>]
 
 betterlockscreen - faster and sweet looking lockscreen for linux systems.
 
@@ -147,6 +147,8 @@ usage:
 			set blur range
 	-r, --resolution res
 			uses a custom resolution
+	--off, --off <timeout>
+			sets custom monitor timeout (<timeout> in seconds)
 
 
 Usage examples:
@@ -165,6 +167,9 @@ betterlockscreen -l pixel -t "custom lockscreen text"
 
 5. Set desktop background
 betterlockscreen -w blur                   # set desktop background with blur effect
+
+6. Lockscreeen with custom monitor off timeout
+betterlockscreen --off 5 -l blur           # set monitor off lockscreen timeout (5 seconds)
 ```
 
 ### Set desktop background on startup

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -6,6 +6,7 @@
 
 # find your resolution so images can be resized to match your screen resolution
 res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
+default_timeout=`cut -d ' ' -f4 <<< $(xset q | sed -n '25p')`
 
 init_filenames() {
 	#$1 resolution
@@ -70,6 +71,9 @@ init_filenames $res
 
 
 prelock() {
+	if [ -n lock_timeout ]; then
+	  xset dpms $lock_timeout
+	fi
 	if [ ! -z "$(pidof dunst)" ]; then
 		pkill -u "$USER" -USR1 dunst
 	fi
@@ -96,6 +100,9 @@ lock() {
 
 
 postlock() {
+	if [ -n lock_timeout ]; then
+	  xset dpms $default_timeout
+	fi
 	if [ ! -z "$(pidof dunst)" ] ; then
 		pkill -u "$USER" -USR2 dunst
 	fi
@@ -375,6 +382,12 @@ usage() {
 	echo '		to set custom lockscreen text (max 31 chars)'
 	echo "		E.g: betterlockscreen -l dim -t \"Don't touch my machine!\""
 	echo '		E.g: betterlockscreen --text "Hi, user!" -s blur'
+	echo
+	echo
+	echo '	--off <timeout>'
+	echo '            to set custom monitor turn off timeout for lockscreen'
+	echo '            timeout is in seconds'
+	echo '            E.g: betterlockscreen -l dim --off 5'
 }
 
 
@@ -413,6 +426,11 @@ for arg in "$@"; do
 
 		-t | --text)
 			locktext="$2"
+			shift 2
+			;;
+
+		--off)
+			lock_timeout="$2"
 			shift 2
 			;;
 

--- a/examples/betterlockscreenrc
+++ b/examples/betterlockscreenrc
@@ -15,3 +15,4 @@ datecolor=ffffffff
 loginbox=00000066
 font="sans-serif"
 locktext='Type password to unlock...'
+lock_timeout=5


### PR DESCRIPTION
This adds an opton to set custom monitor timeout in seconds.
Timeout only applicable during lockscreen.
Reverts back to normal timeout after logging back in.

Closes https://github.com/pavanjadhaw/betterlockscreen/issues/116