### PR TITLE
add the --pass-media-keys argument

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -91,7 +91,8 @@ lock() {
 		--radius=20 --ring-width=4 --veriftext='' --wrongtext='' \
 		--verifcolor="$verifcolor" --timecolor="$timecolor" --datecolor="$datecolor" \
 		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
-		--noinputtext='' --force-clock $lockargs
+		--noinputtext='' --force-clock $lockargs \
+		--pass-media-keys
 }
 
 
@@ -150,7 +151,7 @@ lockselect() {
 logical_px() {
 	# get dpi value from xrdb
 	local DPI=$(xdpyinfo | sed -En "s/\s*resolution:\s*([0-9]*)x([0-9]*)\s.*/\\$2/p" | head -n1)
-	
+
 	# return the default value if no DPI is set
 	if [ -z "$DPI" ]; then
 		echo $1
@@ -167,7 +168,7 @@ logical_px() {
 }
 
 update() {
-	# use 
+	# use
 	background="$1"
 
 	# default blur level; fallback to 1


### PR DESCRIPTION
I sometimes want to have music playing behind the screen when it's locked and control it, but there were no options for it, but I found that i3lock-color has `--pass-media-keys` argument, which enables xf86-music* keys.