### PR TITLE
Update betterlockscreen@.service

### DIFF
--- a/system/betterlockscreen@.service
+++ b/system/betterlockscreen@.service
@@ -3,7 +3,7 @@ Description = Lock screen when going to sleep/suspend
 
 [Service]
 User=%I
-Type=simple
+Type=forking
 Environment=DISPLAY=:0
 ExecStart=/usr/bin/betterlockscreen --lock
 TimeoutSec=infinity


### PR DESCRIPTION
I found that the "Type=simple" option REALLY SHOULDN'T be used, as (at least in my machine) it adds an extra delay when resuming, in wich I can freely use my computer and see everything I'm up to.
"Type=forking", used in similar lockscreen service examples in many forums I've consulted, does work really well, but I'm not sure it's the best option.