### PR TITLE
Add option to pass media keys

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -95,7 +95,8 @@ lock() {
 		--radius=20 --ring-width=4 --veriftext='' --wrongtext='' \
 		--verifcolor="$verifcolor" --timecolor="$timecolor" --datecolor="$datecolor" \
 		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
-		--noinputtext='' --force-clock "$lockargs"
+		--noinputtext='' --force-clock "$lockargs"\
+		$passmediakeys
 }
 
 
@@ -449,6 +450,11 @@ for arg in "$@"; do
 		-b | --blur)
 			blur_level="$2"
 			shift 2
+			;;
+
+		-m | --pass-media-keys)
+			passmediakeys="--pass-media-keys"
+			shift 1
 			;;
 
 		--)

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -386,6 +386,8 @@ usage() {
 	echo "		E.g: betterlockscreen -l dim -t \"Don't touch my machine!\""
 	echo '		E.g: betterlockscreen --text "Hi, user!" -s blur'
 	echo
+	echo '  -m --pass-media-keys'
+	echo '          to keep media keys like volume up/down enabled while locked
 	echo
 	echo '	--off <timeout>'
 	echo '            to set custom monitor turn off timeout for lockscreen'


### PR DESCRIPTION
I added an option to pass media keys, so you can use the media control keys like volume up/down while the screen is locked. This option is passed as command line argument. So betterlockscreen -l -m (or betterlockscreen -l --pass-media-keys) will make you able to use the media keys.