### PR TITLE
Restore previous DPMS setting if turned off

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -7,7 +7,7 @@
 # find your resolution so images can be resized to match your screen resolution
 res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
 default_timeout="$(cut -d ' ' -f4 <<< $(xset q | sed -n '25p'))"
-default_dpms=$(xset q | awk 'NR == 26 {print $(NF)}')
+default_dpms=$(xset q | awk '/^[[:blank:]]*DPMS is/ {print $(NF)}')
 
 init_filenames() {
 	#$1 resolution
@@ -104,9 +104,9 @@ lock() {
 postlock() {
 	if [ ! -z "$lock_timeout" ]; then
 	  xset dpms "$default_timeout"
-      if [ "$default_dpms" = "Disabled" ]; then
-          xset -dpms
-      fi
+	  if [ "$default_dpms" = "Disabled" ]; then
+		xset -dpms
+	  fi
 	fi
 	if [ ! -z "$(pidof dunst)" ] ; then
 		pkill -u "$USER" -USR2 dunst

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -7,6 +7,7 @@
 # find your resolution so images can be resized to match your screen resolution
 res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
 default_timeout="$(cut -d ' ' -f4 <<< $(xset q | sed -n '25p'))"
+default_dpms=$(xset q | awk 'NR == 26 {print $(NF)}')
 
 init_filenames() {
 	#$1 resolution
@@ -103,6 +104,9 @@ lock() {
 postlock() {
 	if [ ! -z "$lock_timeout" ]; then
 	  xset dpms "$default_timeout"
+      if [ "$default_dpms" = "Disabled" ]; then
+          xset -dpms
+      fi
 	fi
 	if [ ! -z "$(pidof dunst)" ] ; then
 		pkill -u "$USER" -USR2 dunst


### PR DESCRIPTION
Added the variable 'default_dpms', which reads the last element of line 26 ("DPMS is Enabled/Disabled").  If it's disabled, it restores that setting upon login.

This fixes an issue where if the user had manually turned off DPMS, the screen will still turn itself off after a while.