### PR TITLE
Changed sbin to usr/bin in service file

### DIFF
--- a/system/betterlockscreen@.service
+++ b/system/betterlockscreen@.service
@@ -9,7 +9,7 @@ Type=simple
 Environment=DISPLAY=:0
 ExecStart=/usr/bin/betterlockscreen --lock
 TimeoutSec=infinity
-ExecStartPost=/sbin/sleep 1
+ExecStartPost=/usr/bin/sleep 1
 
 [Install]
 WantedBy=sleep.target


### PR DESCRIPTION
fixes #155 

not sure why it was sbin to begin with..

Going by https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard it should be either /bin or /usr/bin, I just picked /usr/bin for now since betterlockscreen is in there as well.