### PR TITLE
Same behaviour for '-s -l' and '-l -s'

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -8,6 +8,7 @@
 res=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
 default_timeout="$(cut -d ' ' -f4 <<< $(xset q | sed -n '25p'))"
 default_dpms=$(xset q | awk '/^[[:blank:]]*DPMS is/ {print $(NF)}')
+runsuspend=false
 
 init_filenames() {
 	#$1 resolution
@@ -84,6 +85,8 @@ prelock() {
 
 lock() {
 	#$1 image path
+
+	[[ $runsuspend ]] || lockargs="$lockargs -n"
 
 	i3lock \
 		-t -i "$1" \
@@ -428,7 +431,6 @@ for arg in "$@"; do
 
 		-l | --lock)
 			runlock=true
-			[[ $runsuspend ]] || lockargs="$lockargs -n"
 			if [[ ${2:0:1} = '-' ]]; then
 				shift 1
 			else


### PR DESCRIPTION
I am not sure whether it was intended or not. If it was, please close this PR.

Currently `betterlockscreen` behaves differently when given `-s -l` or `-l -s`.
For `-l -s`, when parsing the `-l` parameter, `$runsuspend` has not been set yet, so `-n` is not appended to `i3lock`, which causes `systemctl suspend` to run after the screen is unlocked.

This PR moves this logic to `lock()` so lock and suspend parameters ordering will not affect `betterlockscreen` behavior.
I have set a default `$runsuspend` on top so argument parsing could modify it and `lock()` will be able to access it (without it, different scope).