### PR TITLE
Better XDG Variable Assignment

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -31,14 +31,14 @@ init_filenames() {
 	wallpaper_cmd='feh --bg-fill --no-fehbg'
 
 	# override defaults with config
-	theme_rc="$HOME/.config/betterlockscreenrc"
+	theme_rc="${XDG_CONFIG_HOME:-$HOME/.config}/betterlockscreenrc"
 	if [ -e "$theme_rc" ]; then
 		source "$theme_rc"
 	fi
 
 	# create folder in ~/.cache/i3lock directory
-	res_folder="$HOME/.cache/i3lock/$1"
-	folder="$HOME/.cache/i3lock/current"
+	res_folder="${XDG_CACHE_HOME:-$HOME/.cache}/i3lock/$1"
+	folder="${XDG_CACHE_HOME:-$HOME/.cache}/i3lock/current"
 	echo "Got" "$@" "$res_folder"
 	if [ ! -d "$folder" -o -n "$2" ]; then
 		rm -rf "$folder"


### PR DESCRIPTION
# Changes
Instead of hardcoding the cache directory to be $HOME/.cache and config to be $HOME/.config, will use whatever the user has as $XDG_CONFIG_HOME and $XDG_CACHE_HOME, falling back to default locations if these are unset via variable expansion. This way, the cache and config files can be placed where the user wants them better.
# Comments
As for the XDG specifications, allows the config and cache files to interact more nicely if the user has manually set these variables to a location of their choice by exporting them in their $SHELL rc or likewise.