### PR TITLE
Fixed lockscreen fading to white for 1 ms before locking

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -86,6 +86,7 @@ lock() {
 	#$1 image path
 
 	i3lock \
+		-c 00000000 \
 		-t -i "$1" \
 		--timepos='x+110:h-70' \
 		--datepos='x+43:h-45' \


### PR DESCRIPTION
The lock-screen fades fades to white (over the background) for about a millisecond before locking. Adding `-c 00000000` to the i3lock options fixed the problem for me. 