### PR TITLE
Added the flag to set timestr in the lockscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ betterlockscreen --lock blur
 
 ## Table of Contents
 
-- [about](#about)
-- [how it works](#how-it-works)
-- [requirements](#requirements)
-- [installation](#installation)
-- [configuration](#configuration)
-- [usage](#usage)
-- [background](#set-desktop-background-on-startup)
-- [keybinding](#keybindings)
-- [lockscreen on suspend](#lockscreen-when-suspendedsystemd-service)
+- [About](#about)
+- [How it works](#how-it-works)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Usage](#usage)
+- [Background](#set-desktop-background-on-startup)
+- [Keybinding](#keybindings)
+- [Lockscreen on suspend](#lockscreen-when-suspendedsystemd-service)
 
 ### About
 
@@ -94,7 +94,7 @@ export PATH="${PATH}:${HOME}/.local/bin/"
 
 #### Debian and derivatives
 
-UtkarshVerma was so kind to provide an installation script for debian based systems, ![check it out here](https://github.com/UtkarshVerma/installer-scripts).
+UtkarshVerma was so kind to provide an installation script for debian based systems, [check it out here](https://github.com/UtkarshVerma/installer-scripts).
 
 #### Void Linux
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -25,6 +25,7 @@ init_filenames() {
 	verifcolor=ffffffff
 	timecolor=ffffffff
 	datecolor=ffffffff
+	timestr="%I:%M"
 	loginbox=00000066
 	font="sans-serif"
 	locktext='Type password to unlock...'
@@ -97,7 +98,7 @@ lock() {
 		--radius=20 --ring-width=4 --veriftext='' --wrongtext='' \
 		--verifcolor="$verifcolor" --timecolor="$timecolor" --datecolor="$datecolor" \
 		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
-		--noinputtext='' --force-clock --pass-media-keys $lockargs
+		--noinputtext='' --force-clock timestr="$timestr" --pass-media-keys $lockargs
 
 }
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -98,7 +98,7 @@ lock() {
 		--radius=20 --ring-width=4 --veriftext='' --wrongtext='' \
 		--verifcolor="$verifcolor" --timecolor="$timecolor" --datecolor="$datecolor" \
 		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
-		--noinputtext='' --force-clock timestr="$timestr" --pass-media-keys $lockargs
+		--noinputtext='' --force-clock --timestr="$timestr" --pass-media-keys $lockargs
 
 }
 

--- a/examples/betterlockscreenrc
+++ b/examples/betterlockscreenrc
@@ -12,6 +12,7 @@ ringwrongcolor=ffffffff
 verifcolor=ffffffff
 timecolor=ffffffff
 datecolor=ffffffff
+timestr="%I:%M"
 loginbox=00000066
 font="sans-serif"
 locktext='Type password to unlock...'


### PR DESCRIPTION
*Hi dev*, using your project as a daily driver, but find a thing that can be added with just a few line of codes.

Added the flag to set the **time formating string** --timestr 

*USAGE* : 
```
--timestr="%H:%M:%S"
              Sets the format used for generating  the  time  string.  See  strf‐
              time(3) for a full list of format specifiers.
```