### PR TITLE
Fix i3lock-color args for new standardized version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ images as lockscreen background depending on argument provided by user.
 
 > Note: Make sure your system has all dependencies satisfied
 
-- [i3lock-color](https://github.com/Raymo111/i3lock-color) - i3lock fork with additional features( >= 2.11-c )
+- [i3lock-color](https://github.com/Raymo111/i3lock-color) - i3lock fork with additional features(`>= 2.13.c.3`)
 - [imagemagick](https://www.imagemagick.org/script/index.php) - To apply effects to images
 - [xdpyinfo](https://www.x.org/archive/X11R7.7/doc/man/man1/xdpyinfo.1.xhtml), [xrandr](https://www.x.org/wiki/Projects/XRandR/), [bc](https://www.gnu.org/software/bc/) and [feh](https://feh.finalrewind.org/) - To find screen resolution, set custom blur level and wallpaper handling.
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -90,17 +90,17 @@ lock() {
 	i3lock \
 		-c 00000000 \
 		-t -i "$1" \
-		--timepos='x+110:h-70' \
-		--datepos='x+43:h-45' \
-		--clock --date-align 1 --datestr "$locktext" --timestr "$time_format" \
-		--insidecolor=$insidecolor --ringcolor=$ringcolor --line-uses-inside \
-		--keyhlcolor=$keyhlcolor --bshlcolor=$bshlcolor --separatorcolor=$separatorcolor \
-		--insidevercolor=$insidevercolor --insidewrongcolor=$insidewrongcolor \
-		--ringvercolor=$ringvercolor --ringwrongcolor=$ringwrongcolor --indpos='x+280:h-70' \
-		--radius=20 --ring-width=4 --veriftext='' --wrongtext='' \
-		--verifcolor="$verifcolor" --timecolor="$timecolor" --datecolor="$datecolor" \
+		--time-pos='x+110:h-70' \
+		--date-pos='x+43:h-45' \
+		--clock --date-align 1 --date-str "$locktext" --time-str "$time_format" \
+		--inside-color=$insidecolor --ring-color=$ringcolor --line-uses-inside \
+		--keyhl-color=$keyhlcolor --bshl-color=$bshlcolor --separator-color=$separatorcolor \
+		--insidever-color=$insidevercolor --insidewrong-color=$insidewrongcolor \
+		--ringver-color=$ringvercolor --ringwrong-color=$ringwrongcolor --ind-pos='x+280:h-70' \
+		--radius=20 --ring-width=4 --verif-text='' --wrong-text='' \
+		--verif-color="$verifcolor" --time-color="$timecolor" --date-color="$datecolor" \
 		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
-		--noinputtext='' --force-clock --pass-media-keys "$lockargs"
+		--noinput-text='' --force-clock --pass-media-keys "$lockargs"
 
 }
 


### PR DESCRIPTION
Hey guys, I had to do a necessary evil and rename i3lock-color args for the latest version. To prevent your wrapper from breaking I've made all (I hope) the necessary changes to your script. The only caveat is now the minimum required version is `2.13.c.3`, which I have also updated your README to.