### PR TITLE
Fix #217 - Change systemd-service type to forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ systemctl disable betterlockscreen@$USER
 
 **Hint:** The systemd-unit expects betterlockscreen to be installed in "/usr/local/bin", so maybe you want to check or change this!
 
+Resources and more informations:
+ * https://gist.github.com/Raymo111/91ffd256b7aca6a85e8a99d6331d3b7b
+ * https://github.com/Raymo111/i3lock-color/issues/174#issuecomment-687149213
+
 ---
 
 ### Countributing

--- a/system/betterlockscreen@.service
+++ b/system/betterlockscreen@.service
@@ -5,7 +5,7 @@ Before=suspend.target
 
 [Service]
 User=%I
-Type=simple
+Type=forking
 Environment=DISPLAY=:0
 ExecStart=/usr/local/bin/betterlockscreen --lock
 TimeoutSec=infinity


### PR DESCRIPTION
**Update:**
Fix #217 - Change systemd-service type to forking
Besides user-feedback I've found many resources showing that it is one common way to use forking here.
I've also found the option "--nofork" for i3lock-color but I'm unsure of the side-effects (i3/i3lock#109)
as it was the less popular solution.

https://gist.github.com/victorhaggqvist/603125bbc0f61a787d89
https://github.com/Raymo111/i3lock-color/issues/174#issuecomment-687149213
https://gist.github.com/Raymo111/91ffd256b7aca6a85e8a99d6331d3b7b

---

Besides user-feedback I've found many resources showing that it is one common way to use forking here.
I've also found the option "--nofork" for i3lock-color but I'm unsure of the side-effects.

https://gist.github.com/victorhaggqvist/603125bbc0f61a787d89
https://www.jvt.me/posts/2019/12/03/lock-before-suspend-systemd/
https://michaelabrahamsen.com/posts/systemd-suspend-i3lock/