### PR TITLE
Fixing Decoration and added New options from i3lock-color

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -90,7 +90,7 @@ lock() {
 	#$1 image path
 
 	# Uncomment bellow line if you are using `i3lock-color` compiled from git directly.
-	# i3lock_git_options="--modif-color="$modifcolor" --modifoutline-color="$modifoutlinecolor" --modifieroutline-width=0.8"
+	# i3lock_git_options="--modif-color=$modifcolor --modifoutline-color=$modifoutlinecolor --modifieroutline-width=0.8"
 
 
 	i3lock \

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -90,9 +90,9 @@ lock() {
 	i3lock \
 		-c 00000000 \
 		-t -i "$1" \
-		--time-pos='x+110:h-70' \
+		--time-pos='x+43:h-70' \
 		--date-pos='x+43:h-45' \
-		--clock --date-align 1 --date-str "$locktext" --time-str "$time_format" \
+		--clock --date-align 1 --date-str "$locktext" --time-align 1 --time-str "$time_format" \
 		--inside-color=$insidecolor --ring-color=$ringcolor --line-uses-inside \
 		--keyhl-color=$keyhlcolor --bshl-color=$bshlcolor --separator-color=$separatorcolor \
 		--insidever-color=$insidevercolor --insidewrong-color=$insidewrongcolor \

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -92,6 +92,7 @@ lock() {
 		-t -i "$1" \
 		--time-pos='x+43:h-70' \
 		--date-pos='x+43:h-45' \
+		--modif-pos='x+280:h-33' \
 		--clock --date-align 1 --date-str "$locktext" --time-align 1 --time-str "$time_format" \
 		--inside-color=$insidecolor --ring-color=$ringcolor --line-uses-inside \
 		--keyhl-color=$keyhlcolor --bshl-color=$bshlcolor --separator-color=$separatorcolor \

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -25,6 +25,8 @@ init_filenames() {
 	verifcolor=ffffffff
 	timecolor=ffffffff
 	datecolor=ffffffff
+	modifcolor=ffffffff
+	modifoutlinecolor=ff0000ff
 	loginbox=00000066
 	font="sans-serif"
 	locktext='Type password to unlock...'
@@ -87,6 +89,10 @@ prelock() {
 lock() {
 	#$1 image path
 
+	# Uncomment bellow line if you are using `i3lock-color` compiled from git directly.
+	# i3lock_git_options="--modif-color="$modifcolor" --modifoutline-color="$modifoutlinecolor" --modifieroutline-width=0.8"
+
+
 	i3lock \
 		-c 00000000 \
 		-t -i "$1" \
@@ -101,7 +107,7 @@ lock() {
 		--radius=20 --ring-width=4 --verif-text='' --wrong-text='' \
 		--verif-color="$verifcolor" --time-color="$timecolor" --date-color="$datecolor" \
 		--time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
-		--noinput-text='' --force-clock --pass-media-keys "$lockargs"
+		--noinput-text='' --force-clock --pass-media-keys $i3lock_git_options "$lockargs" 
 
 }
 


### PR DESCRIPTION
**Fix alignment of time text on passing --time_format** souravdas142/betterlockscreen@efe8699ab4d1193b7229551db7b32b03c8570688

Time text shifted to the left and goes out of the box even Cutted out from the screen if passes different `strftime` like "%I:%M:S %p" to the -tf option default alignment was `center` now is `left`. So from now text expands to the right, May be cutted out of the box but not from the screen at least.

Before the commit - 

![before_time_align](https://user-images.githubusercontent.com/24272753/120065898-598aed80-c091-11eb-92f8-c11738af0a53.png)

After the commit - 

![after_time_align](https://user-images.githubusercontent.com/24272753/120065915-6c052700-c091-11eb-9902-8db351174f33.png)

---

**New i3lock option: --modif-pos added** souravdas142/betterlockscreen@a5c48c2a9d4bd3bc6bb079e7329da14751b7099e

Previously the modkey (e.g. Caps Lock/NUm Lock) texts were entered into the Lock Indicator and looks very ugly. Also those texts were barely Seen under the lock Indicator. So with the `--modif-pos` option we shift these texts slightly down, so that text can't be entered into the lock indicator and can be seen properly.

Before the commit -

![before_repos](https://user-images.githubusercontent.com/24272753/120066039-357bdc00-c092-11eb-9b60-f94994646111.png)


After the commit - 

![after_repos](https://user-images.githubusercontent.com/24272753/120066043-3b71bd00-c092-11eb-9209-65db36ecb8bb.png)


---


**i3lock-color options: --modif-color, --modifoutline-color added**  souravdas142/betterlockscreen@27cfc2d6540ec8adc6c9f3e541597d558f3bb5de

Previously modkey (eg. Caps Lock/Num Lock) texts were black and it can be barely seen over "loginbox", because both colors were almost same. So defining `--modif-color` and `--modifoutline-color` are  helped to seperate "loginbox" color and modkey text colors.

For more info see this PR : Raymo111/i3lock-color#215

 :notebook: Note : Though this new options are added only git version of `i3lock-color`. Those are compiling `i3lock-color` directly from git or or installing `i3lock-color-git` from aur can be used this features.

I have added a variable `i3lock_git_option` and asign those new options to it. This is comented out by default, anyone installing i3color on above condition can uncomment this variable to use it.

Before commit -

![after_repos](https://user-images.githubusercontent.com/24272753/120066382-aff92b80-c093-11eb-819a-371d36f7586e.png)


After commit -

![after_modifcolor](https://user-images.githubusercontent.com/24272753/120066386-b5567600-c093-11eb-8a41-f6ce07241574.png)


