### PR TITLE
Next: Reworked version of #225 for new i3lock-color options "modifcolor" and "modifoutlinecolor"

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -39,6 +39,8 @@ init_config () {
     bgcolor=000000ff
     wallpaper_cmd="feh --bg-fill --no-fehbg"
     time_format="%H:%M:%S"
+    modifcolor=ffffffff
+    modifoutlinecolor=ff0000ff
 
     # read user config
     USER_CONF="$HOME/.config/betterlockscreenrc"
@@ -115,6 +117,7 @@ lock() {
         --verif-color="$verifcolor" --time-color="$timecolor" --date-color="$datecolor" \
         --time-font="$font" --date-font="$font" --layout-font="$font" --verif-font="$font" --wrong-font="$font" \
         --noinput-text="" --force-clock --pass-media-keys --pass-screen-keys --pass-power-keys \
+        --modif-color="$modifcolor" --modifoutline-color="$modifoutlinecolor" --modifieroutline-width=0.8 \
         "${lockargs[@]}"
 }
 

--- a/examples/betterlockscreenrc
+++ b/examples/betterlockscreenrc
@@ -27,3 +27,5 @@ bshlcolor=d23c3dff
 verifcolor=ffffffff
 timecolor=ffffffff
 datecolor=ffffffff
+modifcolor=ffffffff
+modifoutlinecolor=ff0000ff


### PR DESCRIPTION
 Fixing decoration and introducing i3lock_it option for non-released options to use in new advanced part of config (credits to @souravdas142)

As there are some users including me ;) on NixOS which can't modify the script if installed as package, I would prefer a configuration option for this only usable from config-file. I've adjusted to use lockerargs to prepend the options before custom one if enabled, this also resolves the shellcheck issues.

Would you be fine with this kind of solution? I wasn't able to push to your PR...
