### PR TITLE
Fix error when commenting Xft.dpi exists in Xresources

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -169,7 +169,7 @@ lockselect() {
 logical_px() {
 	# get dpi value from xrdb
 	local DPI
-	DPI=$(grep -oP 'Xft.dpi:\s*\K\d+' ~/.Xresources | bc)
+	DPI=$(grep -oP '^\s*Xft.dpi:\s*\K\d+' ~/.Xresources | tail -1 | bc)
 	if [ -z "$DPI" ]; then
 		DPI=$(xdpyinfo | sed -En "s/\s*resolution:\s*([0-9]*)x([0-9]*)\s.*/\\$2/p" | head -n1)
 	fi


### PR DESCRIPTION
Hi, I get an error when update with following Xresources
```sh
# Xft.dpi: 110
Xft.dpi: 144
```
So I fix the regex expression.