### PR TITLE
Fixes introduced bug with autodetection of full path to i3lock-color binary

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -6,16 +6,6 @@
 
 init_config () {
 
-    # resolve i3lock-color binary
-    i3lockcolor_bin="$(command -v i3lock-color)"
-
-    if [[ (! -e "$i3lockcolor_bin") && (-e "$(command -v i3lock)") ]]; then
-        i3lockcolor_bin="$(command -v i3lock)"
-    else
-        echo "Can not find locker-binary as 'i3lock' or 'i3lock-color', please make sure it is in your \$PATH!"
-        exit 1
-    fi
-
     # default options
     display_on=0
     span_image=false
@@ -55,6 +45,10 @@ init_config () {
     if [ -e "$USER_CONF" ]; then
         # shellcheck source=/dev/null
         source "$USER_CONF"
+    fi
+
+    if [[ ! -v $i3lockcolor_bin ]]; then
+        i3lockcolor_bin="i3lock-color"
     fi
 
     # Please make sure to adjust this before release!

--- a/examples/betterlockscreenrc
+++ b/examples/betterlockscreenrc
@@ -9,6 +9,7 @@ dim_level=40
 blur_level=1
 pixel_scale=10,1000
 solid_color=333333
+# i3lockcolor_bin="" # (manually set full path to i3lock-color)
 
 # default theme
 loginbox=00000066


### PR DESCRIPTION
Fixes --lock not working with autodetection when started from zsh, replaced because of stability issues.