### PR TITLE
Support for changing the Xresources path

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -30,6 +30,7 @@ init_filenames() {
 	locktext='Type password to unlock...'
 	wallpaper_cmd='feh --bg-fill --no-fehbg'
 	time_format='%H:%M:%S'
+	xresources_file="$HOME/.Xresources"
 
 	# override defaults with config
 	theme_rc="$HOME/.config/betterlockscreenrc"
@@ -169,7 +170,7 @@ lockselect() {
 logical_px() {
 	# get dpi value from xrdb
 	local DPI
-	DPI=$(grep -oP 'Xft.dpi:\s*\K\d+' ~/.Xresources | bc)
+	DPI=$(grep -osP 'Xft.dpi:\s*\K\d+' "$xresources_file" | bc)
 	if [ -z "$DPI" ]; then
 		DPI=$(xdpyinfo | sed -En "s/\s*resolution:\s*([0-9]*)x([0-9]*)\s.*/\\$2/p" | head -n1)
 	fi
@@ -489,6 +490,11 @@ for arg in "$@"; do
 
 		-tf | --time_format)
 			time_format="$2"
+			shift 2
+			;;
+
+		-xf | --xresources_file)
+			xresources_file="$2"
 			shift 2
 			;;
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -422,6 +422,12 @@ usage() {
 	echo '		to set the time format used by i3lock-color'
 	echo '		see the i3lock or strftime man pages for more details.'
 	echo '		E.g: betterlockscreen -l dim -tf "%I:%M %p"'
+	echo
+	echo
+	echo '	-xf --xresources_file <path_to_xresources>'
+	echo '		to set the xresources file path when updating.'
+	echo '		see the i3lock or strftime man pages for more details.'
+	echo '		E.g: betterlockscreen -xf ~/.config/X11/Xresources -u image.png'
 }
 
 


### PR DESCRIPTION
In this pull request, a flag is added to specify the directory for the Xresources file. This allows to have this file in other directories such as the one specified in the XDG Base directory specification without having issues with backward compatibility.

On the other hand, the `s` flag was added to the grep command in order to avoid seeing the following error when running the program:
![image](https://user-images.githubusercontent.com/31258166/124001762-91d86100-d99a-11eb-8989-a2067f64d621.png)
